### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/kerberos_sspi.py
+++ b/kerberos_sspi.py
@@ -24,7 +24,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-if sys.version_info >= (3,0):
+if sys.version_info >= (3,1):
+    def decodestring(stringvalue):
+        return base64.decodebytes(stringvalue.encode("ascii"))
+    def encodestring(bytesvalue):
+        return base64.encodebytes(bytesvalue).decode("utf-8")
+elif sys.version_info == (3,0):
     def decodestring(stringvalue):
         return base64.decodestring(stringvalue.encode("ascii"))
     def encodestring(bytesvalue):


### PR DESCRIPTION
The functions `base64.decodestring()` and `base64.encodestring()` are deprecated since Python 3.1, [Python 3.9 has removed](https://docs.python.org/3/whatsnew/3.9.html#removed) them finally.

Since the new API has been introduced with 3.1, there's another if-branch explicitly supporting 3.0. 

CC @may-day 