### PR TITLE
pywin32 has official wheels for py3 now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup (
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Systems Administration :: Authentication/Directory"
         ],
-    install_requires = ["pypiwin32"]
+    install_requires = ["pywin32"]
 )


### PR DESCRIPTION
For Py3 the pywin32 project now provides official wheels, so no need to use the fork anymore.
This fixes:
https://github.com/may-day/kerberos-sspi/issues/9